### PR TITLE
Added Ansible Review for proper playbook linting/review

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ MAINTAINER Anton Kasperovich <anton.kaspiarovich@gmail.com>
 
 ENV ANSIBLE_VERSION 2.2.0.0
 ENV ANSIBLE_LINT_VERSION 3.4.4
+ENV ANSIBLE_REVIEW_VERSION 0.13.0
 
 RUN apk --update add sudo \
     git \
@@ -24,6 +25,7 @@ RUN apk --update add --virtual build-dependencies \
     openssl-dev \
     && pip install -U ansible==$ANSIBLE_VERSION \
     && pip install -U ansible-lint==$ANSIBLE_LINT_VERSION \
+    && pip install -U ansible-review==$ANSIBLE_REVIEW_VERSION \
     && apk del build-dependencies
 
 RUN mkdir -p /etc/ansible \


### PR DESCRIPTION
This allows to use "ansible-review <playbook>.yml" to verify if the provided YAML file is valid. Besides having ansible-lint functionality, it can also verify formatting and provide suggestions for best practices